### PR TITLE
Various fixes to make docker-compose work nicely

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ WORKDIR /app/client-hello-poisoning/custom-tls
 RUN cargo build
 RUN cargo install --path .
 
-CMD ["/usr/local/cargo/bin/custom-tls", "--verbose", "--certs", "/app/rustls/test-ca/rsa/end.fullchain", "--key", "/app/rustls/test-ca/rsa/end.rsa", "-p", "8443", "http"]
+ENV CERTS /app/rustls/test-ca/rsa/end.fullchain
+ENV KEY /app/rustls/test-ca/rsa/end.rsa
+
+CMD ["sh", "-c", "/usr/local/cargo/bin/custom-tls --verbose --certs $CERTS --key $KEY -p 8443 http"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN cargo install --path .
 ENV CERTS /app/rustls/test-ca/rsa/end.fullchain
 ENV KEY /app/rustls/test-ca/rsa/end.rsa
 
-CMD ["sh", "-c", "/usr/local/cargo/bin/custom-tls --verbose --certs $CERTS --key $KEY -p 8443 http"]
+CMD ["sh", "-c", "/usr/local/cargo/bin/custom-tls --verbose --certs $CERTS --key $KEY -p 443 http"]

--- a/client-hello-poisoning/custom-dns/Dockerfile
+++ b/client-hello-poisoning/custom-dns/Dockerfile
@@ -15,6 +15,6 @@ COPY . /app
 
 RUN pip install -r requirements.txt
 
-EXPOSE 53
+EXPOSE 53/udp
 
 CMD ["sh", "-c", "python alternate-dns.py ${DOMAIN},${TARGET_IP} -b 0.0.0.0 -t ${INITIAL_IP} -d 8.8.8.8"]

--- a/client-hello-poisoning/custom-dns/Dockerfile
+++ b/client-hello-poisoning/custom-dns/Dockerfile
@@ -17,4 +17,4 @@ RUN pip install -r requirements.txt
 
 EXPOSE 53/udp
 
-CMD ["sh", "-c", "python alternate-dns.py ${DOMAIN},${TARGET_IP} -b 0.0.0.0 -t ${INITIAL_IP} -d 8.8.8.8"]
+CMD ["sh", "-c", "python -u alternate-dns.py ${DOMAIN},${TARGET_IP} -b 0.0.0.0 -t ${INITIAL_IP} -d 8.8.8.8"]

--- a/client-hello-poisoning/custom-tls/src/main.rs
+++ b/client-hello-poisoning/custom-tls/src/main.rs
@@ -316,7 +316,7 @@ impl Connection {
 
     fn send_http_response_once(&mut self) {
         let response = format!(
-            "HTTP/1.1 301 Moved Permanently\r\nAccess-Control-Allow-Origin: *\r\nLocation: {}\r\nConnection: close\r\n",
+            "HTTP/1.1 301 Moved Permanently\r\nAccess-Control-Allow-Origin: *\r\nLocation: {}\r\nConnection: close\r\n\r\n",
             get_redirect_location()
         );
         std::thread::sleep_ms(get_sleep_duration());

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,21 @@ services:
     - "8443:8443"
     volumes:
     - .:/code
+    - /etc/letsencrypt/live/ssltest.jmaddux.com:/certs/live/ssltest.jmaddux.com:ro
+    - /etc/letsencrypt/archive/ssltest.jmaddux.com:/certs/archive/ssltest.jmaddux.com:ro
+    environment:
+    - CERTS=/certs/live/ssltest.jmaddux.com/fullchain.pem
+    - KEY=/certs/live/ssltest.jmaddux.com/privkey.pem
     links:
     - redis
   custom-dns:
     build: client-hello-poisoning/custom-dns
     ports:
     - "5353:53"
+    environment:
+    - INITIAL_IP=198.51.100.1
+    - DOMAIN=ssltest.jmaddux.com
+    - TARGET_IP=127.0.0.1
     volumes:
     - .:/code
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   custom-tls:
     build: .
     ports:
-    - "8443:8443"
+    - "443:443"
     volumes:
     - .:/code
     - /etc/letsencrypt/live/ssltest.jmaddux.com:/certs/live/ssltest.jmaddux.com:ro
@@ -16,7 +16,7 @@ services:
   custom-dns:
     build: client-hello-poisoning/custom-dns
     ports:
-    - "5353:53"
+    - "53:53/udp"
     environment:
     - INITIAL_IP=198.51.100.1
     - DOMAIN=ssltest.jmaddux.com


### PR DESCRIPTION
As docker-compose isn't documented in the README, I've made it Just Work™. It should now come up listening on 53/udp and 443/tcp, and the only work required is to use certbot beforehand and replace the domain and IP in `docker-compose.yml`.

Also fix a couple of minor bugs in the process.