### PR TITLE
Not retrieving IP and incrementing spoof_count if not A type

### DIFF
--- a/client-hello-poisoning/custom-dns/alternate-dns.py
+++ b/client-hello-poisoning/custom-dns/alternate-dns.py
@@ -139,8 +139,7 @@ def spoofed_answer(answer, domain, IP):
 def main_loop(udps):
     while True:
         data, addr, type, domain, answer = receiveData(udps)
-        ip = get_spoofed_IP(domain, addr)
-        if type == "A" and ip:
+        if type == "A" and (ip := get_spoofed_IP(domain, addr)):
             print("Answering with %s" % ip)
             answer = spoofed_answer(answer, domain, ip)
             sendData(udps, addr, answer)


### PR DESCRIPTION
If I understand the script well, getting the spoofed IP will also increment the spoof_count, while we want to reserve that for A type requests, or we won't have the correct chain we want.

The current state will increment the spoof_count, no matter the type of DNS request that are made. With the edit I did, it will only try to retrieve the spoofed IP on A requests, avoiding incrementing the spoof_count.

I profit from this to thank you for the project! :-)