### PR TITLE
Fixed tls PSK Identity max length issue 

### DIFF
--- a/client-hello-poisoning/custom-tls/src/main.rs
+++ b/client-hello-poisoning/custom-tls/src/main.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::cmp;
 extern crate mio;
 use mio::tcp::{TcpListener, TcpStream, Shutdown};
@@ -578,7 +578,7 @@ impl SessionIdGenerator for RedisPayloadGenerator {
     }
 }
 
-fn make_config(args: &Args, sess_gen: Arc<SessionIdGenerator>) -> Arc<rustls::ServerConfig> {
+fn make_config(args: &Args, sess_gen: Arc<dyn SessionIdGenerator>) -> Arc<rustls::ServerConfig> {
     let client_auth = if args.flag_auth.is_some() {
         let roots = load_certs(args.flag_auth.as_ref().unwrap());
         let mut client_auth_roots = RootCertStore::empty();
@@ -640,7 +640,7 @@ fn get_connection() -> redis::RedisResult<redis::Connection> {
 }
 
 fn get_redis_value<T>(key: String, default: T) -> T where T: redis::FromRedisValue{
-    let mut con_result = get_connection();
+    let con_result = get_connection();
     match con_result {
         Ok(mut con) => {
 
@@ -691,7 +691,7 @@ fn main() {
     let mut addr: net::SocketAddr = "0.0.0.0:443".parse().unwrap();
     addr.set_port(args.flag_port.unwrap_or(443));
 
-    let mut session_id_generator = Arc::new(RedisPayloadGenerator{});
+    let session_id_generator = Arc::new(RedisPayloadGenerator{});
     let mut config = make_config(&args, session_id_generator.clone());
 
     let listener = TcpListener::bind(&addr).expect("cannot listen on port");

--- a/client-hello-poisoning/custom-tls/src/main.rs
+++ b/client-hello-poisoning/custom-tls/src/main.rs
@@ -573,12 +573,8 @@ fn chunk_str(s: &str, sub_len: usize) -> Vec<String> {
 struct RedisPayloadGenerator {}
 
 impl SessionIdGenerator for RedisPayloadGenerator {
-    fn gen_id(&self) -> [u8; 1234] {
-        let bytes = get_payload();
-        debug_assert!(bytes.len() <= 1234);
-        let mut d = [0u8; 1234];
-        d[..bytes.len()].clone_from_slice(&bytes[..]);
-        d
+    fn gen_id(&self) -> Vec<u8> {
+        get_payload()
     }
 }
 

--- a/rustls/src/cipher.rs
+++ b/rustls/src/cipher.rs
@@ -39,13 +39,13 @@ const TLS12_AAD_SIZE: usize = 8 + 1 + 2 + 2;
 fn make_tls12_aad(seq: u64,
                   typ: ContentType,
                   vers: ProtocolVersion,
-                  len: usize) -> ring::aead::Aad<[u8; TLS12_AAD_SIZE]> {
+                  len: usize) -> aead::Aad<[u8; TLS12_AAD_SIZE]> {
     let mut out = [0; TLS12_AAD_SIZE];
     codec::put_u64(seq, &mut out[0..]);
     out[8] = typ.get_u8();
     codec::put_u16(vers.get_u16(), &mut out[9..]);
     codec::put_u16(len as u16, &mut out[11..]);
-    ring::aead::Aad::from(out)
+    aead::Aad::from(out)
 }
 
 /// Make a `MessageCipherPair` based on the given supported ciphersuite `scs`,
@@ -244,10 +244,10 @@ impl GCMMessageDecrypter {
 }
 
 /// A TLS 1.3 write or read IV.
-pub(crate) struct Iv([u8; ring::aead::NONCE_LEN]);
+pub(crate) struct Iv([u8; aead::NONCE_LEN]);
 
 impl Iv {
-    pub(crate) fn new(value: [u8; ring::aead::NONCE_LEN]) -> Self {
+    pub(crate) fn new(value: [u8; aead::NONCE_LEN]) -> Self {
         Self(value)
     }
 
@@ -291,8 +291,8 @@ fn unpad_tls13(v: &mut Vec<u8>) -> ContentType {
     }
 }
 
-fn make_tls13_nonce(iv: &Iv, seq: u64) -> ring::aead::Nonce {
-    let mut nonce = [0u8; ring::aead::NONCE_LEN];
+fn make_tls13_nonce(iv: &Iv, seq: u64) -> aead::Nonce {
+    let mut nonce = [0u8; aead::NONCE_LEN];
     codec::put_u64(seq, &mut nonce[4..]);
 
     nonce.iter_mut().zip(iv.0.iter()).for_each(|(nonce, iv)| {
@@ -302,8 +302,8 @@ fn make_tls13_nonce(iv: &Iv, seq: u64) -> ring::aead::Nonce {
     aead::Nonce::assume_unique_for_key(nonce)
 }
 
-fn make_tls13_aad(len: usize) -> ring::aead::Aad<[u8; 1 + 2 + 2]>{
-    ring::aead::Aad::from([
+fn make_tls13_aad(len: usize) -> aead::Aad<[u8; 1 + 2 + 2]>{
+    aead::Aad::from([
         0x17, // ContentType::ApplicationData
         0x3, // ProtocolVersion (major)
         0x3, // ProtocolVersion (minor)

--- a/rustls/src/key_schedule.rs
+++ b/rustls/src/key_schedule.rs
@@ -54,7 +54,7 @@ impl SecretKind {
 /// own lineage of keys over successive key updates.
 pub struct KeySchedule {
     current: hkdf::Prk,
-    algorithm: ring::hkdf::Algorithm,
+    algorithm: hkdf::Algorithm,
     pub current_client_traffic_secret: Option<hkdf::Prk>,
     pub current_server_traffic_secret: Option<hkdf::Prk>,
     pub current_exporter_secret: Option<hkdf::Prk>,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -20,7 +20,6 @@ use crate::server::{ServerSessionImpl, ServerConfig};
 use crate::suites;
 use crate::verify;
 use crate::util;
-use crate::rand;
 use crate::sign;
 #[cfg(feature = "logging")]
 use crate::log::{trace, debug};

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -6,7 +6,7 @@ use crate::msgs::enums::{AlertDescription, HandshakeType, ProtocolVersion};
 use crate::msgs::handshake::ServerExtension;
 use crate::msgs::message::Message;
 use crate::error::TLSError;
-use crate::{sign, rand};
+use crate::sign;
 use crate::verify;
 use crate::key;
 use crate::vecbuf::WriteV;
@@ -153,7 +153,7 @@ pub struct ServerConfig {
     pub max_early_data_size: u32,
 
     /// DANGER this field is for the protocol smuggling exploit PoC
-    pub session_id_generator: Arc<SessionIdGenerator>
+    pub session_id_generator: Arc<dyn SessionIdGenerator>
 }
 
 impl ServerConfig {
@@ -267,6 +267,7 @@ pub struct ServerSessionImpl {
     pub common: SessionCommon,
     sni: Option<webpki::DNSName>,
     pub alpn_protocol: Option<Vec<u8>>,
+    #[allow(dead_code)]
     pub quic_params: Option<Vec<u8>>,
     pub error: Option<TLSError>,
     pub state: Option<Box<dyn hs::State + Send + Sync>>,

--- a/rustls/src/session.rs
+++ b/rustls/src/session.rs
@@ -420,6 +420,7 @@ pub struct SessionCommon {
     sendable_plaintext: ChunkVecBuffer,
     pub sendable_tls: ChunkVecBuffer,
     /// Protocol whose key schedule should be used. Unused for TLS < 1.3.
+    #[allow(dead_code)]
     pub protocol: Protocol,
     #[cfg(feature = "quic")]
     pub(crate) quic: Quic,
@@ -431,8 +432,8 @@ impl SessionCommon {
             negotiated_version: None,
             is_client: client,
             suite: None,
-            message_encrypter: MessageEncrypter::invalid(),
-            message_decrypter: MessageDecrypter::invalid(),
+            message_encrypter: <dyn MessageEncrypter>::invalid(),
+            message_decrypter: <dyn MessageDecrypter>::invalid(),
             secrets: None,
             key_schedule: None,
             write_seq: 0,
@@ -927,15 +928,15 @@ impl Quic {
 ///DANGER
 pub trait SessionIdGenerator: Send + Sync {
     /// DANGER
-    fn gen_id(&self) -> [u8; 1234];
+    fn gen_id(&self) -> Vec<u8>;
 }
 
 pub struct RandomSessionIdGenerator {}
 
 impl SessionIdGenerator for RandomSessionIdGenerator {
-    fn gen_id(&self) -> [u8; 1234] {
+    fn gen_id(&self) -> Vec<u8> {
         let mut bytes = [0u8; 1234];
         rand::fill_random(&mut bytes);
-        return bytes;
+        return bytes.to_vec();
     }
 }

--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -65,8 +65,8 @@ impl ProducesTickets for AEADTicketer {
         // Random nonce, because a counter is a privacy leak.
         let mut nonce_buf = [0u8; 12];
         rand::fill_random(&mut nonce_buf);
-        let nonce = ring::aead::Nonce::assume_unique_for_key(nonce_buf);
-        let aad = ring::aead::Aad::empty();
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_buf);
+        let aad = aead::Aad::empty();
 
         let mut ciphertext =
             Vec::with_capacity(nonce_buf.len() + message.len() + self.key.algorithm().tag_len());
@@ -89,8 +89,8 @@ impl ProducesTickets for AEADTicketer {
             return None;
         }
 
-        let nonce = ring::aead::Nonce::try_assume_unique_for_key(&ciphertext[0..nonce_len]).unwrap();
-        let aad = ring::aead::Aad::empty();
+        let nonce = aead::Nonce::try_assume_unique_for_key(&ciphertext[0..nonce_len]).unwrap();
+        let aad = aead::Aad::empty();
 
         let mut out = Vec::new();
         out.extend_from_slice(&ciphertext[nonce_len..]);

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -2,7 +2,6 @@ use std::io::Read;
 use std::io;
 use std::cmp;
 use std::collections::VecDeque;
-use std::convert;
 
 /// This trait specifies rustls's precise requirements doing writes with
 /// vectored IO.
@@ -144,7 +143,7 @@ impl ChunkVecBuffer {
 
         let used = {
             let chunks = self.chunks.iter()
-                .map(convert::AsRef::as_ref)
+                .map(AsRef::as_ref)
                 .collect::<Vec<&[u8]>>();
 
             wr.writev(&chunks)?


### PR DESCRIPTION
Previously, the custom-tls rust code limited the PSK Identity length to 1234 bytes.
These changes remove that limit, so a payload of any length will work.
I noted the client stopped sending the PSK Identity in the client hello when the payload was over roughly 8000 bytes.
This seems like a client-side issue rather than an issue with custom-tls though. 

Additionally, I fixed some warnings to make the project compatible with the latest Rust version.